### PR TITLE
Add spectator mode and adjust match duration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
       <section class="controls">
         <button id="train-toggle">Start Training</button>
         <button id="watch-once">Watch Exhibition Match</button>
+        <button id="watch-training">Watch Training</button>
       </section>
 
       <section class="status">

--- a/public/styles.css
+++ b/public/styles.css
@@ -89,6 +89,12 @@ body {
   transform: translateY(-1px);
 }
 
+.controls button.active {
+  background: rgba(255, 112, 67, 0.35);
+  border-color: rgba(255, 112, 67, 0.8);
+  box-shadow: 0 0 0 2px rgba(255, 112, 67, 0.15);
+}
+
 .status {
   display: flex;
   flex-direction: column;

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ export const FIELD_HEIGHT = 36;
 export const CANVAS_WIDTH = 800;
 export const CANVAS_HEIGHT = 480;
 export const TICK_RATE = 60;
-export const MAX_STEPS = TICK_RATE * 60; // 60 seconds
+export const MAX_STEPS = TICK_RATE * 30; // 30 seconds
 export const BALL_RADIUS = 1.2;
 export const PLAYER_RADIUS = 1.5;
 export const CONE_RADIUS = 0.8;
@@ -35,6 +35,7 @@ export const ATTRIBUTES = [
 export const INITIAL_ATTRIBUTE_SCORE = 5; // out of 10
 export const REWARD_WIN = 500;
 export const REWARD_LOSS = -500;
+export const REWARD_DRAW = -50;
 export const OBSERVATION_SIZE =
   5 * 2 + // players pos/vel/facing
   4 + // ball pos/vel

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const canvas = document.getElementById("pitch");
 const ctx = canvas.getContext("2d");
 const toggleBtn = document.getElementById("train-toggle");
 const watchBtn = document.getElementById("watch-once");
+const watchTrainingBtn = document.getElementById("watch-training");
 const epsEl = document.getElementById("eps");
 const avgStepsEl = document.getElementById("avg-steps");
 const queuedEl = document.getElementById("queued-updates");
@@ -14,8 +15,9 @@ const versionEls = {
   fred: document.getElementById("fred-version")
 };
 
-const trainer = new Trainer(updateStatus);
+const trainer = new Trainer(updateStatus, drawScene);
 let renderHandle = null;
+let watchingTraining = false;
 
 (async () => {
   await trainer.initAgents();
@@ -29,6 +31,15 @@ toggleBtn.addEventListener("click", async () => {
   if (trainer.shouldRun) {
     trainer.loop();
   }
+});
+
+watchTrainingBtn.addEventListener("click", () => {
+  watchingTraining = !watchingTraining;
+  trainer.setSpectate(watchingTraining);
+  watchTrainingBtn.textContent = watchingTraining
+    ? "Stop Watching Training"
+    : "Watch Training";
+  watchTrainingBtn.classList.toggle("active", watchingTraining);
 });
 
 watchBtn.addEventListener("click", async () => {

--- a/src/match.js
+++ b/src/match.js
@@ -1,6 +1,6 @@
 import { FootballEnv } from "./env.js";
 import { ensureAgent } from "./agent.js";
-import { REWARD_WIN, REWARD_LOSS, ACTIONS } from "./config.js";
+import { REWARD_WIN, REWARD_LOSS, REWARD_DRAW, ACTIONS } from "./config.js";
 
 export async function runEpisode({ p1Who, p2Who, epsilon }, opts = {}) {
   const { render = false, renderer = null } = opts;
@@ -22,6 +22,7 @@ export async function runEpisode({ p1Who, p2Who, epsilon }, opts = {}) {
     done = result.done;
     if (render && renderer) {
       renderer(env);
+      await waitForNextFrame();
     }
     if (done) {
       let rewards = {};
@@ -30,8 +31,7 @@ export async function runEpisode({ p1Who, p2Who, epsilon }, opts = {}) {
       } else if (result.winner === 2) {
         rewards = { [p1Who]: REWARD_LOSS, [p2Who]: REWARD_WIN };
       } else {
-        // draw => discard
-        break;
+        rewards = { [p1Who]: REWARD_DRAW, [p2Who]: REWARD_DRAW };
       }
       transitions[p1Who].push({
         state: prevObs,
@@ -65,4 +65,11 @@ export async function runEpisode({ p1Who, p2Who, epsilon }, opts = {}) {
     }
   }
   return { transitions, steps: env.stepCount };
+}
+
+function waitForNextFrame() {
+  if (typeof requestAnimationFrame === "function") {
+    return new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+  return new Promise((resolve) => setTimeout(resolve, 16));
 }


### PR DESCRIPTION
## Summary
- add a Watch Training control and styling so users can follow live episodes while models train
- enable the trainer loop to render frames when spectating and throttle rendering for watchable playback
- shorten matches to 30 seconds and penalise scoreless draws to keep training feedback informative

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db4ee0f438832b9df91ba7ff8640f0