### PR TITLE
Add quick access button for session stats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
         <button id="train-toggle">Start Training</button>
         <button id="watch-once">Watch Exhibition Match</button>
         <button id="watch-training">Watch Training</button>
+        <button id="view-stats" class="secondary">View Stats</button>
         <div
           id="training-indicator"
           class="training-indicator"
@@ -34,7 +35,7 @@
         </div>
       </section>
 
-      <section class="status">
+      <section id="stats-section" class="status">
         <div class="status-card">
           <h2>Agent Versions</h2>
           <div class="agent-versions">
@@ -48,7 +49,7 @@
             </div>
           </div>
         </div>
-        <div class="status-card">
+        <div id="session-stats" class="status-card">
           <h2>Session Stats</h2>
           <dl class="stats-list">
             <div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -84,6 +84,10 @@ body {
   transition: background 0.2s ease, transform 0.2s ease;
 }
 
+.controls button.secondary {
+  background: rgba(255, 255, 255, 0.04);
+}
+
 .controls button:hover {
   background: rgba(255, 112, 67, 0.25);
   transform: translateY(-1px);
@@ -157,6 +161,10 @@ body {
   padding: 1rem;
   border: 1px solid var(--border);
   box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
+}
+
+.status-card.highlight {
+  animation: stats-highlight 2s ease-in-out;
 }
 
 .agent-versions {
@@ -240,5 +248,17 @@ body {
 
   .controls button {
     flex: 1 1 200px;
+  }
+}
+
+@keyframes stats-highlight {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 112, 67, 0.8);
+  }
+  30% {
+    box-shadow: 0 0 25px rgba(255, 112, 67, 0.8);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 112, 67, 0);
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,11 +7,14 @@ const ctx = canvas.getContext("2d");
 const toggleBtn = document.getElementById("train-toggle");
 const watchBtn = document.getElementById("watch-once");
 const watchTrainingBtn = document.getElementById("watch-training");
+const viewStatsBtn = document.getElementById("view-stats");
 const trainingIndicator = document.getElementById("training-indicator");
 const trainingIndicatorText = document.getElementById("training-indicator-text");
 const epsEl = document.getElementById("eps");
 const avgStepsEl = document.getElementById("avg-steps");
 const queuedEl = document.getElementById("queued-updates");
+const statsSection = document.getElementById("stats-section");
+const sessionStatsCard = document.getElementById("session-stats");
 const versionEls = {
   gregory: document.getElementById("gregory-version"),
   fred: document.getElementById("fred-version")
@@ -58,6 +61,18 @@ watchBtn.addEventListener("click", async () => {
   const pairing = pickPlayers();
   const epsilon = 0.01;
   await runEpisode({ ...pairing, epsilon }, { render: true, renderer: drawScene });
+});
+
+viewStatsBtn?.addEventListener("click", () => {
+  statsSection?.scrollIntoView({ behavior: "smooth", block: "center" });
+  if (!sessionStatsCard) return;
+  sessionStatsCard.classList.remove("highlight");
+  // Force reflow so the animation can replay if the user clicks repeatedly.
+  void sessionStatsCard.offsetWidth;
+  sessionStatsCard.classList.add("highlight");
+  setTimeout(() => {
+    sessionStatsCard.classList.remove("highlight");
+  }, 2000);
 });
 
 async function refreshVersions() {


### PR DESCRIPTION
## Summary
- add a dedicated View Stats control so the session metrics are easy to find
- smooth-scroll to the stats section and pulse the card when the new control is used
- lightly adjust styling for the new button and highlight animation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db55ce38e0832b8df808e1b55edad9