### PR TITLE
Improve agent training stability and exploration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ export const EPSILON_START = 0.2;
 export const EPSILON_END = 0.05;
 export const EPSILON_DECAY_STEPS = 10000;
 export const GAMMA = 0.99;
+export const LEARNING_RATE = 0.00025;
 export const TARGET_SYNC_INTERVAL = 2000;
 export const LOCAL_BATCH_SIZE = 32;
 export const LOCAL_UPDATE_STEPS = 2;


### PR DESCRIPTION
## Summary
- persist an Adam optimizer per agent so training retains momentum state and reset it when new weights arrive
- switch the temporal difference target to a double-DQN style update with Huber loss for better stability
- expose the learning rate in configuration for reuse when building optimizers

## Testing
- `npm run build` *(fails: esbuild binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5732de1c832bad4ebcc095b0b841